### PR TITLE
Added endAdornment to OrderParcelDetails dialog

### DIFF
--- a/src/orders/components/OrderParcelDetails/OrderParcelDetails.tsx
+++ b/src/orders/components/OrderParcelDetails/OrderParcelDetails.tsx
@@ -1,4 +1,9 @@
-import { Card, Checkbox, FormControlLabel } from "@material-ui/core";
+import {
+  Card,
+  Checkbox,
+  FormControlLabel,
+  InputAdornment
+} from "@material-ui/core";
 import {
   CardContent,
   Table,
@@ -391,6 +396,9 @@ const OrderParcelDetails: React.FC<OrderParcelDetailsProps> = props => {
                       <TableCell className={classes.colName}>
                         <TextField
                           InputProps={{
+                            endAdornment: (
+                              <InputAdornment position="end">kg</InputAdornment>
+                            ),
                             classes: {
                               input: classes.nameInput
                             }
@@ -409,6 +417,9 @@ const OrderParcelDetails: React.FC<OrderParcelDetailsProps> = props => {
                       <TableCell className={classes.colName}>
                         <TextField
                           InputProps={{
+                            endAdornment: (
+                              <InputAdornment position="end">cm</InputAdornment>
+                            ),
                             classes: {
                               input: classes.nameInput
                             }
@@ -430,6 +441,9 @@ const OrderParcelDetails: React.FC<OrderParcelDetailsProps> = props => {
                       <TableCell className={classes.colName}>
                         <TextField
                           InputProps={{
+                            endAdornment: (
+                              <InputAdornment position="end">cm</InputAdornment>
+                            ),
                             classes: {
                               input: classes.nameInput
                             }
@@ -451,6 +465,9 @@ const OrderParcelDetails: React.FC<OrderParcelDetailsProps> = props => {
                       <TableCell className={classes.colName}>
                         <TextField
                           InputProps={{
+                            endAdornment: (
+                              <InputAdornment position="end">cm</InputAdornment>
+                            ),
                             classes: {
                               input: classes.nameInput
                             }


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
